### PR TITLE
Fix issue premature response to client

### DIFF
--- a/lib/zipline/fake_stream.rb
+++ b/lib/zipline/fake_stream.rb
@@ -29,7 +29,7 @@ module Zipline
     end
 
     def <<(x)
-      return if x.nil?
+      return if x.blank?
       throw "bad class #{x.class}" unless x.class == String
       @pos += x.bytesize
       @block.call(x.to_s)


### PR DESCRIPTION
In rails 4 not all data would be received by the client. Response would
end prematurely when empty string appended to FakeStream.

https://github.com/rubyzip/rubyzip/blob/v1.0.0/lib/zip/entry.rb#L260
