### PR TITLE
Check that Paperclip is defined before using it

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -27,7 +27,7 @@ module Zipline
 
     def normalize(file)
       unless is_io?(file)
-        if file.respond_to?(:url) && !file.is_a?(Paperclip::Attachment)
+        if file.respond_to?(:url) && (!defined?(::Paperclip::Attachment) || !file.is_a?(::Paperclip::Attachment))
           file = file
         elsif file.respond_to? :file
           file = File.open(file.file)


### PR DESCRIPTION
We don't know it Paperclip is being bundled by application, check if it is defined.
User might not be using paperclip and we don't them to have to add it to Gemfile just to use zipline
