### PR TITLE
Fixing get_size for Carrierwave - my carrierwave S3 file doesn't respond...

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -65,7 +65,7 @@ module Zipline
     end
 
     def get_size(file)
-      if is_io?(file)
+      if is_io?(file) || file.respond_to?(:size)
         file.size
       elsif file.respond_to? :content_length
         file.content_length


### PR DESCRIPTION
... to content_length and neither is IO - this fixes this problem as it does respond to :size
