### PR TITLE
Use zip filename in Content-Disposition as quoted string.

### DIFF
--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -18,7 +18,7 @@ require "zipline/zip_generator"
 module Zipline
   def zipline(files, zipname = 'zipline.zip')
     zip_generator = ZipGenerator.new(files)
-    headers['Content-Disposition'] = "attachment; filename=#{zipname}"
+    headers['Content-Disposition'] = "attachment; filename=\"#{zipname}\""
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true
     response.cache_control[:public] ||= false

--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -18,7 +18,7 @@ require "zipline/zip_generator"
 module Zipline
   def zipline(files, zipname = 'zipline.zip')
     zip_generator = ZipGenerator.new(files)
-    headers['Content-Disposition'] = "attachment; filename=\"#{zipname}\""
+    headers['Content-Disposition'] = "attachment; filename=\"#{zipname.gsub '"', '\"'}\""
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true
     response.cache_control[:public] ||= false


### PR DESCRIPTION
To allow to use space in zip filename it should be quoted as described in [RFC2616, 19.5.1 Content-Disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html). Otherwise the filename will be truncated. e.g. "ab cd.zip" => "ab".