### PR TITLE
Set uncompressed size in local file header to 0

### DIFF
--- a/lib/zipline/output_stream.rb
+++ b/lib/zipline/output_stream.rb
@@ -17,12 +17,16 @@ module Zipline
 
     def put_next_entry(entry_name, size)
       new_entry = Zip::Entry.new(@file_name, entry_name)
-      new_entry.size = size
 
       #THIS IS THE MAGIC, tells zip to look after data for size, crc
       new_entry.gp_flags = new_entry.gp_flags | 0x0008
 
       super(new_entry)
+
+      # Uncompressed size in the local file header must be zero when bit 3
+      # of the general purpose flags is set, so set the size after the header
+      # has been written.
+      new_entry.size = size
     end
 
     # just reset state, no rewinding required


### PR DESCRIPTION
The ZIP spec [1] describes in section 4.4.9 that the uncompressed size
field is set to zero in the local file header if bit 3 of the general
purpose flags is set, which zipline does.

Some applications actually care about this, e.g. Powerpoint regards a
file as corrupt when the uncompressed size and bit 3 are set.

[1] https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT