### PR TITLE
Bump rubyzip dependency

### DIFF
--- a/lib/zipline/fake_stream.rb
+++ b/lib/zipline/fake_stream.rb
@@ -29,7 +29,7 @@ module Zipline
     end
 
     def <<(x)
-      return if x.blank?
+      return if x.nil? || x.size <= 0
       throw "bad class #{x.class}" unless x.class == String
       @pos += x.bytesize
       @block.call(x.to_s)

--- a/lib/zipline/output_stream.rb
+++ b/lib/zipline/output_stream.rb
@@ -4,7 +4,7 @@ module Zipline
   class OutputStream < Zip::OutputStream
 
     #we need to be able to hand out own custom output in order to stream to browser
-    def initialize(io)
+    def initialize(io, stream=false, encrypter=nil)
       # Create an io stream thing
       super StringIO.new, true
       # Overwrite it with my own

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Zipline::VERSION
 
-  gem.add_dependency 'rubyzip', ['>= 1.0', '<= 1.1.2']
+  gem.add_dependency 'rubyzip', ['>= 1.0', '<= 1.1.7']
   gem.add_dependency 'rails', ['>= 3.2.1', '< 4.3']
   gem.add_dependency 'curb'
 end


### PR DESCRIPTION
- Add new Zip::OutputStream initialize parameters
- Use nil? and size instead of blank? when adding data to stream to avoid
  invalid UTF-8 byte sequence