### PR TITLE
Support CarrierWave::Uploader

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -28,6 +28,10 @@ module Zipline
     # Currently support carrierwave and paperclip local and remote storage.
     # returns a hash of the form {url: aUrl} or {file: anIoObject}
     def normalize(file)
+      if defined?(CarrierWave::Uploader::Base) && file.is_a?(CarrierWave::Uploader::Base)
+        file = file.file
+      end
+
       if defined?(Paperclip) && file.is_a?(Paperclip::Attachment)
         if file.options[:storage] == :filesystem
           {file: File.open(file.path)}

--- a/spec/lib/zipline/zip_generator_spec.rb
+++ b/spec/lib/zipline/zip_generator_spec.rb
@@ -41,6 +41,30 @@ describe Zipline::ZipGenerator do
           expect(normalized[:file]).to be_a File
         end
       end
+      context "CarrierWave::Uploader::Base" do
+        let(:uploader) { Class.new(CarrierWave::Uploader::Base).new }
+
+        context "Remote" do
+          let(:file){ CarrierWave::Storage::Fog::File.new(nil,nil,nil) }
+          it "extracts the url" do
+            allow(uploader).to receive(:file).and_return(file)
+            allow(file).to receive(:url).and_return('fakeurl')
+            expect(File).not_to receive(:open)
+            expect(generator.normalize(uploader)).to eq({url: 'fakeurl'})
+          end
+        end
+
+        context "Local" do
+          let(:file){ CarrierWave::SanitizedFile.new(Tempfile.new('t')) }
+          it "creates a File" do
+            allow(uploader).to receive(:file).and_return(file)
+            allow(file).to receive(:path).and_return('spec/fakefile.txt')
+            normalized = generator.normalize(uploader)
+            expect(normalized.keys).to include(:file)
+            expect(normalized[:file]).to be_a File
+          end
+        end
+      end
     end
     context "Paperclip" do
       context "Local" do 


### PR DESCRIPTION
It supports instance of CarrierWave uploader that inherits from `CarrierWave::Uploader::Base`. When using CarrierWave, mount the uploader as follows.

```rb
class AvatarUploader < CarrierWave::Uploader::Base
  storage :file
end

class User < ActiveRecord::Base
  mount_uploader :avatar, AvatarUploader
end
```

If you want to distribute the mounted file, you can do as follows.

```rb
def index
  users = User.all
  files =  users.map{ |user| [user.avatar, "#{user.username}.png"] }
  zipline( files, 'avatars.zip')
end
```

Fix #28 