### PR TITLE
Use Time.now.httpdate instead of Time.now.to_s

### DIFF
--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -19,6 +19,6 @@ module Zipline
     response.sending_file = true
     response.cache_control[:public] ||= false
     self.response_body = zip_generator
-    self.response.headers['Last-Modified'] = Time.now.to_s
+    self.response.headers['Last-Modified'] = Time.now.httpdate
   end
 end


### PR DESCRIPTION
I believe it's better to use `Time.now.httpdate` (returns a string which represents the time as RFC 1123 date of HTTP-date defined by RFC 2616) instead of `Time.now.to_s`.
This helps to avoid situations like this `ArgumentError: not RFC 2616 compliant date: "2017-08-25 13:26:14 +0000"`