### PR TITLE
Close file descriptor after writing.

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -68,6 +68,7 @@ module Zipline
           c.perform
         elsif file[:file]
           IO.copy_stream(file[:file], writer_for_file)
+          file[:file].close
         else
           raise(ArgumentError, 'Bad File/Stream')
         end


### PR DESCRIPTION
It was leaking open files before. I tested using Shrine and [this code](https://stackoverflow.com/a/10922046/1928168) where I saw a lot of open files before this change.

Also, I messed up with my branching, so #34 is included in this PR as well ._.

I suggest to either accept just this PR (if there's no objections) or I can rebase this one after #34 is merged.