### PR TITLE
Add support for ActiveStorage::Blobs

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -42,10 +42,10 @@ module Zipline
         {url: file.url}
       elsif defined?(CarrierWave::SanitizedFile) && file.is_a?(CarrierWave::SanitizedFile)
         {file: File.open(file.path)}
-      elsif defined?(ActiveStorage::Blob) && file.is_a?(ActiveStorage::Blob)
-        {blob: file}
       elsif is_io?(file)
         {file: file}
+      elsif file.respond_to? :service_url
+        {url: file.service_url}
       elsif file.respond_to? :url
         {url: file.url}
       elsif file.respond_to? :path

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -44,7 +44,7 @@ module Zipline
         {file: File.open(file.path)}
       elsif is_io?(file)
         {file: file}
-      elsif file.respond_to? :service_url
+      elsif defined?(ActiveStorage::Blob) && file.is_a?(ActiveStorage::Blob)
         {url: file.service_url}
       elsif file.respond_to? :url
         {url: file.url}
@@ -71,8 +71,6 @@ module Zipline
         elsif file[:file]
           IO.copy_stream(file[:file], writer_for_file)
           file[:file].close
-        elsif file[:blob]
-          writer_for_file << file[:blob].download
         else
           raise(ArgumentError, 'Bad File/Stream')
         end

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -42,6 +42,8 @@ module Zipline
         {url: file.url}
       elsif defined?(CarrierWave::SanitizedFile) && file.is_a?(CarrierWave::SanitizedFile)
         {file: File.open(file.path)}
+      elsif defined?(ActiveStorage::Blob) && file.is_a?(ActiveStorage::Blob)
+        {blob: file}
       elsif is_io?(file)
         {file: file}
       elsif file.respond_to? :url
@@ -69,6 +71,8 @@ module Zipline
         elsif file[:file]
           IO.copy_stream(file[:file], writer_for_file)
           file[:file].close
+        elsif file[:blob]
+          writer_for_file << file[:blob].download
         else
           raise(ArgumentError, 'Bad File/Stream')
         end

--- a/spec/lib/zipline/zip_generator_spec.rb
+++ b/spec/lib/zipline/zip_generator_spec.rb
@@ -85,14 +85,19 @@ describe Zipline::ZipGenerator do
       end
     end
     context "ActiveStorage::Blob" do
+      module ActiveStorage
+        class Filename; end
+        class Blob; end
+      end
+
       let(:tempfile){ Tempfile.new('t').read }
       let(:filename) do
-        fn = double('ActiveStorage::Filename')
+        fn = ActiveStorage::Filename.new()
         allow(fn).to receive(:to_s).and_return('spec/fakefile.txt')
         fn
       end
       let(:file) do
-        f = double('ActiveStorage::Blob')
+        f = ActiveStorage::Blob.new()
         allow(f).to receive(:filename).and_return(filename)
         allow(f).to receive(:service_url).and_return('fakeurl')
         f

--- a/spec/lib/zipline/zip_generator_spec.rb
+++ b/spec/lib/zipline/zip_generator_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'tempfile'
 
 describe Zipline::ZipGenerator do
-  class ActiveStorage::Blob; end
-
   before { Fog.mock! }
   let(:file_attributes){ {
     key: 'fog_file_tests',
@@ -96,16 +94,14 @@ describe Zipline::ZipGenerator do
       let(:file) do
         f = double('ActiveStorage::Blob')
         allow(f).to receive(:filename).and_return(filename)
-        allow(f).to receive(:download).and_return(tempfile)
-        allow(f).to receive(:is_a?)
-        allow(f).to receive(:is_a?).with(ActiveStorage::Blob).and_return(true)
+        allow(f).to receive(:service_url).and_return('fakeurl')
         f
       end
       it "creates a File" do
         allow_any_instance_of(Object).to receive(:defined?).and_return(true)
         normalized = generator.normalize(file)
-        expect(normalized.keys).to include(:blob)
-        expect(normalized[:blob]).to eq(file)
+        expect(normalized.keys).to include(:url)
+        expect(normalized[:url]).to eq('fakeurl')
       end
     end
     context "Fog" do


### PR DESCRIPTION
Add support for ActiveStorage::Blobs.

The tests aren't the best, `require 'active_storage'` directly without passing through all the Railties stuff doesn't import `ActiveStorage::Blob`, so I had to get creative with the tests, I'm open for suggestions.