### PR TITLE
Url comes first instead io

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -42,12 +42,12 @@ module Zipline
         {url: file.url}
       elsif defined?(CarrierWave::SanitizedFile) && file.is_a?(CarrierWave::SanitizedFile)
         {file: File.open(file.path)}
+      elsif file.respond_to? :url
+        {url: file.url}
       elsif is_io?(file)
         {file: file}
       elsif defined?(ActiveStorage::Blob) && file.is_a?(ActiveStorage::Blob)
         {url: file.service_url}
-      elsif file.respond_to? :url
-        {url: file.url}
       elsif file.respond_to? :path
         {file: File.open(file.path)}
       elsif file.respond_to? :file


### PR DESCRIPTION
Hello fringd,
in this commit https://github.com/fringd/zipline/commit/b1b0a1cc86452790afc0cfe9ce8058bcf5641d6e
you change the order of normalize checking. This makes downloading failed while trying to download from s3.

In before b1b0a1, you check url first instead io. So I think, the behavior should be same.
I can provide the video while using version 1.0 or higher failed.

Thanks.