### PR TITLE
Allow Rails 6 preview versions

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
 
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 5.0.0']
-  gem.add_dependency 'rails', ['>= 3.2.1', '< 5.3']
+  gem.add_dependency 'rails', ['>= 3.2.1', '< 6.0']
   gem.add_dependency 'curb', ['>= 0.8.0', '< 0.10']
 end


### PR DESCRIPTION
This allows the gem to be used with Rails 6.0.0.beta-1 for example.

Part of #42.