### PR TITLE
Update README for streaming example with modification times

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ avatars = [
 ]
 file_mappings = avatars
   .lazy  # Lazy allows us to begin sending the download immediately instead of waiting to download everything
-  .map { |url, path| [open(url), path] }
+  .map { |url, path, options| [open(url), path, options] }
 zipline(file_mappings, 'avatars.zip')
 ```
 


### PR DESCRIPTION
If the options hash isn't mapped, modification times won't be reflected in the resulting zip.