### PR TITLE
Replace curb with Net::HTTP

### DIFF
--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -1,5 +1,4 @@
 require "zipline/version"
-require 'curb'
 require 'zip_tricks'
 require "zipline/zip_generator"
 

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -56,6 +56,8 @@ module Zipline
         {file: File.open(file.path)}
       elsif file.respond_to? :file
         {file: File.open(file.file)}
+      elsif is_url?(file)
+        {url: file}
       else
         raise(ArgumentError, 'Bad File/Stream')
       end
@@ -92,6 +94,11 @@ module Zipline
 
     def is_active_storage_one?(file)
       defined?(ActiveStorage::Attached::One) && file.is_a?(ActiveStorage::Attached::One)
+    end
+
+    def is_url?(url)
+      url = URI.parse(url) rescue false
+      url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
     end
   end
 end

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -64,14 +64,13 @@ module Zipline
     def write_file(streamer, file, name, options)
       streamer.write_deflated_file(name, options) do |writer_for_file|
         if file[:url]
-          the_remote_url = file[:url]
-          c = Curl::Easy.new(the_remote_url) do |curl|
-            curl.on_body do |data|
-              writer_for_file << data
-              data.bytesize
+          the_remote_uri = URI(file[:url])
+
+          Net::HTTP.get_response(the_remote_uri) do |response|
+            response.read_body do |chunk|
+              writer_for_file << chunk
             end
           end
-          c.perform
         elsif file[:file]
           IO.copy_stream(file[:file], writer_for_file)
           file[:file].close

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 5.0.0']
   gem.add_dependency 'rails', ['>= 3.2.1', '< 6.1']
-  gem.add_dependency 'curb', ['>= 0.8.0', '< 0.10']
 end


### PR DESCRIPTION
Fixes #51.

You can check out https://github.com/aried3r/zipline-rails-6-poc/tree/ar/replace_curb. ~The commit previous to HEAD uses zipline master, the current HEAD uses my patched version (see this PR).~ The commit previous to HEAD does not work, because it doesn't contain the patch applied in this PR which checks if a string is probably a URL.

~In my local tests, neither curb nor Net::HTTP directly stream the download from the wire but only begin streaming once the download completes. I also tried playing around with `IO.copy_stream`, but I'm not  exactly sure what's going on.~
Chunks from the wire are directly streamed to the writer.

~However, both versions exhibit the exact same behavior.~ I didn't test the curb version with the current form of this PR.

Here's a ~100MB video, if you want to test with some bigger files. http://www.nasa.gov/downloadable/videos/the_expedition_43_soyuz_spacecraft_is_prepared_for_launch.mp4