### PR TITLE
Loosen zip_tricks dependency

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
-  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 5.0.0']
+  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 5.1.0']
   gem.add_dependency 'rails', ['>= 3.2.1', '< 6.1']
 end


### PR DESCRIPTION
Is there any way we can remove the upper bounds altogether to reduce maintenance burden? Big gems like devise also did this, as did paper_trail, however a bit more conservatively, using a warning.

https://github.com/heartcombo/devise/commit/54fb58226976984bf7b322a2136d25921093fa85
https://github.com/paper-trail-gem/paper_trail/commit/a107146dedc6e1af8c5cf226a44c1adc3b223c0a

Edit: https://github.com/WeTransfer/zip_tricks/blob/master/CHANGELOG.md