### PR TITLE
Loosen zip_tricks dependency (again)

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
-  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 6.0']
+  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
   gem.add_dependency 'rails', ['>= 3.2.1', '< 6.1']
 end

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
-  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 5.1.0']
+  gem.add_dependency 'zip_tricks', ['>= 4.2.1', '<= 6.0']
   gem.add_dependency 'rails', ['>= 3.2.1', '< 6.1']
 end


### PR DESCRIPTION
Needed for a fix in zip_tricks 5.3, which fixes a bug with rubyzip 2.1 and above.

Allows rubyzip >= 2 to be used.

I hope this change is okay, since it assumes `zipline` will keep working for all `zip_tricks` releases until 6, but it should reduce the noise of my PRs here. Also, since it seems I keep coming back to this gem for updates, at least there's a high chance I'll open PRs if it should stop working :D.

Anyway, since [I asked for a new release](https://github.com/fringd/zipline/pull/55#issuecomment-627254673) a new release of `zip_tricks` with [this fix](https://github.com/WeTransfer/zip_tricks/pull/67) was released. Which I cannot use with `zipline` until we loosen the dependency again.