### PR TITLE
Fewer gems in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,9 @@ gemspec
 
 group :development, :test do
   gem 'rspec', '~> 3'
-  gem 'fog'
   gem 'fog-aws'
   gem 'activesupport'
-  gem 'aws-sdk'
+  gem 'aws-sdk-s3'
   gem 'carrierwave'
   gem 'paperclip'
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,4 @@ group :development, :test do
   gem 'carrierwave'
   gem 'paperclip'
   gem 'rake'
-  gem 'rake-rspec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,12 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
-require "rake/rspec"
-task :default => :spec
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task default: :spec
+rescue LoadError
+  # no rspec available
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,7 @@ require 'rspec'
 require 'active_support'
 require 'active_support/core_ext'
 require 'zipline'
-require 'aws-sdk'
 require 'paperclip'
-require 'fog'
 require 'fog-aws'
 require 'carrierwave'
 
@@ -20,8 +18,6 @@ CarrierWave.configure do |config|
 	}
 
 end
-
-
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
Literally dozens fewer dependencies during development.

Hint was taken from `fog`s post-install message:

```
Post-install message from fog:
------------------------------
Thank you for installing fog!

IMPORTANT NOTICE:
If there's a metagem available for your cloud provider, e.g. `fog-aws`,
you should be using it instead of requiring the full fog collection to avoid
unnecessary dependencies.

'fog' should be required explicitly only if the provider you use doesn't yet
have a metagem available.
------------------------------
```