### PR TITLE
swap dependency: rails -> actionpack, relax version restriction on actionpack (allowing Rails 6.1)

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
+  gem.add_dependency 'actionpack', ['>= 3.2.1', '< 7.0']
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
-  gem.add_dependency 'rails', ['>= 3.2.1', '< 6.1']
 end


### PR DESCRIPTION
Thanks for the gem!

After reading issue https://github.com/fringd/zipline/issues/68 (add support for Rails 6.1), I've browsed through the code, and I think we don't even need the entire Rails gem here, but only [actionpack](https://github.com/rails/rails/tree/master/actionpack) to handle the request/response that this gem aims to hook into.

Since there haven't been any changes to ActionPack that should break anything of this gem (I think! :D), we can relax requirements to `< 7.0`.

I've sorted the dependencies in alphabetical order (default rubocop suggestion) --feel free to sort this back if you mind.

closes https://github.com/fringd/zipline/issues/68