### PR TITLE
Update CI: drop Ruby 2.3, add Ruby 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
   - 2.7
+  - 3.0


### PR DESCRIPTION
* Updates CI to run against Ruby 3.0
* Updates CI to not run against Ruby 2.3 anymore (EOL since quite a while already, 2.4 was released in 2016 and is EOL as well already)

I've also git-ignored `.ruby-version`, since I wanted that file to run the tests locally against different Ruby versions.

Ruby 3.0: `16 examples, 0 failures` ✅   🚀 