### PR TITLE
support passing an ActiveStorage::Filename object as filename (Rails >= 5.2)

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -31,7 +31,7 @@ module Zipline
       write_buffer = ZipTricks::WriteBuffer.new(fake_io_writer, write_buffer_size)
       ZipTricks::Streamer.open(write_buffer) do |streamer|
         @files.each do |file, name, options = {}|
-          handle_file(streamer, file, name, options)
+          handle_file(streamer, file, name.to_s, options)
         end
       end
       write_buffer.flush! # for any remaining writes

--- a/spec/lib/zipline/zip_generator_spec.rb
+++ b/spec/lib/zipline/zip_generator_spec.rb
@@ -161,6 +161,7 @@ describe Zipline::ZipGenerator do
       end
 
       def create_filename
+        # Rails wraps Blob#filname in this class since Rails 5.2
         ActiveStorage::Filename.new('test')
       end
     end


### PR DESCRIPTION
`ActiveStorage::Blob#filename` actually returns an `ActiveStorage::Filename` object since Rails >= 5.2 (added [here](https://github.com/rails/rails/commit/9330d01ada9ce6768d14c59b99cd3860e209737a#diff-5d98a8ec8926dad66a1c94a7c8a15a26794b3c60a0603f4d057ec51da0be9bbd)). Thus, when following the suggestions from the Readme

```ruby
users = User.all
files = users.map { |user| [user.avatar, user.avatar.filename] }
zipline(files, 'avatars.zip')
```

then `user.avatar.filename` is such `ActiveStorage::Filename`. Passing this object further down the line to `zip_tricks` an error is raised here:

https://github.com/WeTransfer/zip_tricks/blob/5b871c0a4321bfcd443d23bdfbb081f30c6d3a96/lib/zip_tricks/streamer.rb#L516
```ruby
 # zip_tricks/lib/zip_tricks/streamer.rb
  def remove_backslash(filename)
    filename.tr('\\', '_')
  end
```

we can call `.to_s` on the filename: https://github.com/rails/rails/blob/5-2-stable/activestorage/app/models/active_storage/filename.rb#L68,

calling `.to_s` on a string is redundant, thus no harm is to be expected when just calling `.to_s` on the name passed in by the user I think.


closes https://github.com/fringd/zipline/issues/67