### PR TITLE
Add: options parameter to zipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ class MyController < ApplicationController
     # responds to :url, :path or :file.
     # :modification_time is an optional third argument you can use.
     files = users.map{ |user| [user.avatar, "#{user.username}.png", modification_time: 1.day.ago] }
+<<<<<<< Updated upstream
     zipline(files, 'avatars.zip')
+=======
+
+    # we can force duplicate file names to be renamed, or raise an error
+    # we can also pass in our own writer if required to conform with the Delegated [ZipTricks::Streamer object](https://github.com/WeTransfer/zip_tricks/blob/main/lib/zip_tricks/streamer.rb#L147) object.
+    
+    zipline(files, 'avatars.zip', auto_rename_duplicate_filenames: true) 
+>>>>>>> Stashed changes
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -41,15 +41,10 @@ class MyController < ApplicationController
     # responds to :url, :path or :file.
     # :modification_time is an optional third argument you can use.
     files = users.map{ |user| [user.avatar, "#{user.username}.png", modification_time: 1.day.ago] }
-<<<<<<< Updated upstream
-    zipline(files, 'avatars.zip')
-=======
 
     # we can force duplicate file names to be renamed, or raise an error
     # we can also pass in our own writer if required to conform with the Delegated [ZipTricks::Streamer object](https://github.com/WeTransfer/zip_tricks/blob/main/lib/zip_tricks/streamer.rb#L147) object.
-    
     zipline(files, 'avatars.zip', auto_rename_duplicate_filenames: true) 
->>>>>>> Stashed changes
   end
 end
 ```

--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -11,8 +11,8 @@ require "zipline/zip_generator"
 #   end
 # end
 module Zipline
-  def zipline(files, zipname = 'zipline.zip')
-    zip_generator = ZipGenerator.new(files)
+  def zipline(files, zipname = 'zipline.zip', **kwargs_for_new)
+    zip_generator = ZipGenerator.new(files, **kwargs_for_new)
     headers['Content-Disposition'] = "attachment; filename=\"#{zipname.gsub '"', '\"'}\""
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -3,8 +3,9 @@
 module Zipline
   class ZipGenerator
     # takes an array of pairs [[uploader, filename], ... ]
-    def initialize(files)
+    def initialize(files,  **kwargs_for_new)
       @files = files
+      @kwargs_for_new = kwargs_for_new
     end
 
     #this is supposed to be streamed!
@@ -29,7 +30,7 @@ module Zipline
       # this might pose a problem. Unlikely that it will be an issue here though.
       write_buffer_size = 16 * 1024
       write_buffer = ZipTricks::WriteBuffer.new(fake_io_writer, write_buffer_size)
-      ZipTricks::Streamer.open(write_buffer) do |streamer|
+      ZipTricks::Streamer.open(write_buffer, **@kwargs_for_new) do |streamer|
         @files.each do |file, name, options = {}|
           handle_file(streamer, file, name.to_s, options)
         end


### PR DESCRIPTION
### What is this commit?

Allows for options to be passed in (if required).

### Why do we all need it?

Sometimes we may need to pass in options in order to access specific functionality. 

In my particular case, I want to pass in the options to allow for duplicate file names to be renamed. The default is `false` but I would like it to be true. Things will still work with the default, as it was before.

```ruby
zipline(@documents.map{ |d| [d.file, d.filename]}, "name.zip", auto_rename_duplicate_filenames: true)
```

Those options are then passed on to the delegated Ziptricks streamer and everyone's happy!

### Tests

I did not find a test for the zipline helper, so I have simply passed in the parameter and tested it manually on my end. I'm not sure how we would test the `Zipline::zipline` helper method.

Please let me know if there are any issues and I hope to be able to work towards clearing them up.

Ben
