### PR TITLE
Fix call to ZipTricks::Streamer#write_deflated_file to match method signature

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -80,7 +80,7 @@ module Zipline
     end
 
     def write_file(streamer, file, name, options)
-      streamer.write_deflated_file(name, options) do |writer_for_file|
+      streamer.write_deflated_file(name, **options.slice(:modification_time)) do |writer_for_file|
         if file[:url]
           the_remote_uri = URI(file[:url])
 

--- a/spec/lib/zipline/zip_generator_spec.rb
+++ b/spec/lib/zipline/zip_generator_spec.rb
@@ -199,7 +199,7 @@ describe Zipline::ZipGenerator do
       it 'passes a string as filename to ZipTricks' do
         allow(file).to receive(:url).and_return('fakeurl')
         expect_any_instance_of(ZipTricks::Streamer).to receive(:write_deflated_file)
-          .with('test', {})
+          .with('test')
         generator.each { |_| 'Test' }
       end
     end
@@ -220,7 +220,7 @@ describe Zipline::ZipGenerator do
         generator.each { |_| 'Test' }
       end
 
-      it 'passes the options hash to ZipTricks' do
+      it 'passes the options hash to ZipTricks as kwargs' do
         allow(file).to receive(:url).and_return('fakeurl')
         expect_any_instance_of(ZipTricks::Streamer).to receive(:write_deflated_file)
           .with(anything, modification_time: mtime)
@@ -239,10 +239,30 @@ describe Zipline::ZipGenerator do
         generator.each { |_| 'Test' }
       end
 
-      it 'passes the options hash to ZipTricks' do
+      it 'passes the options hash to ZipTricks as kwargs' do
         allow(file).to receive(:url).and_return('fakeurl')
         expect_any_instance_of(ZipTricks::Streamer).to receive(:write_deflated_file)
-          .with(anything, {})
+          .with(anything)
+        generator.each { |_| 'Test' }
+      end
+    end
+
+    context 'with extra invalid options' do
+      let(:mtime) { 1.day.ago }
+      let(:generator) do
+        Zipline::ZipGenerator.new([[file, 'test', modification_time: mtime, extra: 'invalid']])
+      end
+
+      it 'passes the whole options hash through handle_file' do
+        expect(generator).to receive(:handle_file)
+          .with(anything, anything, anything, { modification_time: mtime, extra: 'invalid' })
+        generator.each { |_| 'Test' }
+      end
+
+      it 'only passes the kwargs to ZipTricks that it expects (i.e., :modification_time)' do
+        allow(file).to receive(:url).and_return('fakeurl')
+        expect_any_instance_of(ZipTricks::Streamer).to receive(:write_deflated_file)
+          .with(anything, modification_time: mtime)
         generator.each { |_| 'Test' }
       end
     end


### PR DESCRIPTION
Fixes #75.

The previous implementation took advantage of kwarg/hash interoperability in method calls that was deprecated in Ruby 2.7.2 and dropped in Ruby 3.