### PR TITLE
Use `content_disposition` gem for encoding filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-          - jruby-9.3
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -1,3 +1,4 @@
+require 'content_disposition'
 require "zipline/version"
 require 'zip_tricks'
 require "zipline/zip_generator"
@@ -13,7 +14,7 @@ require "zipline/zip_generator"
 module Zipline
   def zipline(files, zipname = 'zipline.zip')
     zip_generator = ZipGenerator.new(files)
-    headers['Content-Disposition'] = ActionDispatch::Http::ContentDisposition.format(disposition: 'attachment', filename: zipname)
+    headers['Content-Disposition'] = ContentDisposition.format(disposition: 'attachment', filename: zipname)
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true
     response.cache_control[:public] ||= false

--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -1,7 +1,6 @@
 require "zipline/version"
 require 'zip_tricks'
 require "zipline/zip_generator"
-require 'uri'
 
 # class MyController < ApplicationController
 #   include Zipline
@@ -14,7 +13,7 @@ require 'uri'
 module Zipline
   def zipline(files, zipname = 'zipline.zip')
     zip_generator = ZipGenerator.new(files)
-    headers['Content-Disposition'] = "attachment; filename=\"#{zipname.gsub '"', '\"'}\"; filename*=UTF-8''#{URI.encode_www_form_component(zipname)}"
+    headers['Content-Disposition'] = ActionDispatch::Http::ContentDisposition.format(disposition: 'attachment', filename: zipname)
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true
     response.cache_control[:public] ||= false

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
-  gem.required_ruby_version = ">= 2.3"
+  gem.required_ruby_version = ">= 2.7"
 
-  gem.add_dependency 'actionpack', ['>= 3.2.1', '< 8.0']
+  gem.add_dependency 'actionpack', ['>= 6.0', '< 8.0']
   gem.add_dependency 'content_disposition', '~> 1.0'
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
 end

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -21,4 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'actionpack', ['>= 6.0', '< 8.0']
   gem.add_dependency 'content_disposition', '~> 1.0'
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
+
+  # https://github.com/rspec/rspec-mocks/issues/1457
+  gem.add_development_dependency 'rspec-mocks', ['~> 3.10', '!= 3.10.3']
 end

--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -16,6 +16,9 @@ Gem::Specification.new do |gem|
   gem.version       = Zipline::VERSION
   gem.licenses      = ['MIT']
 
+  gem.required_ruby_version = ">= 2.3"
+
   gem.add_dependency 'actionpack', ['>= 3.2.1', '< 8.0']
+  gem.add_dependency 'content_disposition', '~> 1.0'
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
 end


### PR DESCRIPTION
The current method wrongly encodes filenames, the easiest example being a filename containing a space.

Filename: `test 1.zip`
Prior to #81: `test 1.zip`
After #81: `test+1.zip`
After this PR: `test 1.zip`

I've verified locally that the example given in RFC6266 using the euro sign (€) still works.

This is a draft PR, because the [`ActionDispatch::Http::ContentDisposition`](https://github.com/rails/rails/blob/6-0-stable/actionpack/lib/action_dispatch/http/content_disposition.rb) is `:nodoc:` which I believe means private API for Rails.
Additionally, it only exists starting Rails 6.0 while this gem supports Rails (well, `actionpack`) 3.2.1 and above.

https://github.com/fringd/zipline/blob/b5b7d74c16f010f100707358f90158bf911b8ce3/zipline.gemspec#L19

To resolve this, we could raise the minimum `actionpack` version to 6.0 or use a gem like [`content_disposition`](https://github.com/shrinerb/content_disposition) which extracted the code from Rails (supports Ruby 2.3 and above, while this gem I believe has no lower bound for supported Ruby versions) or copy the code to this gem and maintain it ourselves if necessary.

WDYT? Ping @dot.
