### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test (${{ matrix.ruby-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - head
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - jruby-9.3
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
This PR adds a GitHub Actions file to run CI to replace the now defunct TravisCI.org.  It adds Ruby 3.1 to the CI matrix.

The changes in this PR - https://github.com/fringd/zipline/pull/76/files - made the gem incompatible with all Ruby versions earlier than 2.7, so the list of compatible Rubies has been truncated from the Travis config to reflect that. 