### PR TITLE
Rails 7.1 compatibility

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -13,6 +13,11 @@ module Zipline
       throw "stop!"
     end
 
+    # Rails 7.1 compat
+    def to_ary
+      self
+    end
+
     def each(&block)
       fake_io_writer = ZipTricks::BlockWrite.new(&block)
       # ZipTricks outputs lots of strings in rapid succession, and with


### PR DESCRIPTION
Recent Rails & Rack versions call #to_ary on body before calling #each.


```
Puma caught this error: undefined method `to_ary' for #<Zipline::ZipGenerator:0x00007f933011fda8 @files=[[#<Tempfile:/tmp/open-uri20231114-960363-6x308h>, "Example Project_Kevin_Gubitosa_3.pdf"], [#<Tempfile:/tmp/open-uri20231114-960363-ngzc01>, "Example Project_Ernie_Mozzafari_1.pdf"]], @kwargs_for_new={}>

        @buf.to_ary
            ^^^^^^^
Did you mean?  to_param (NoMethodError)
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/actionpack-7.1.1/lib/action_dispatch/http/response.rb:107:in `to_ary'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/actionpack-7.1.1/lib/action_dispatch/http/response.rb:509:in `to_ary'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/rack-2.2.8/lib/rack/body_proxy.rb:41:in `method_missing'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/rack-2.2.8/lib/rack/body_proxy.rb:41:in `method_missing'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/rack-2.2.8/lib/rack/body_proxy.rb:41:in `method_missing'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/rack-2.2.8/lib/rack/body_proxy.rb:41:in `method_missing'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/rack-2.2.8/lib/rack/body_proxy.rb:41:in `method_missing'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/puma-6.4.0/lib/puma/request.rb:183:in `prepare_response'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/puma-6.4.0/lib/puma/request.rb:133:in `handle_request'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/puma-6.4.0/lib/puma/server.rb:443:in `process_client'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/puma-6.4.0/lib/puma/server.rb:241:in `block in run'
/home/micah/.rvm/gems/ruby-3.1.3@smh/gems/puma-6.4.0/lib/puma/thread_pool.rb:155:in `block in spawn_thread'
```