### PR TITLE
Fixes rails 7.1.2 compatibility

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -13,6 +13,10 @@ module Zipline
       throw "stop!"
     end
 
+    def to_ary
+      nil
+    end
+
     def each(&block)
       fake_io_writer = ZipTricks::BlockWrite.new(&block)
       # ZipTricks outputs lots of strings in rapid succession, and with


### PR DESCRIPTION
* Buffer#to_ary now calls "each" without a block when the body doesn't have a 'to_ary' method
* fixes https://github.com/fringd/zipline/issues/91