### PR TITLE
fix rails 7 compatibility

### DIFF
--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -14,6 +14,8 @@ module Zipline
     end
 
     def each(&block)
+      return to_enum(:each) unless block_given?
+
       fake_io_writer = ZipTricks::BlockWrite.new(&block)
       # ZipTricks outputs lots of strings in rapid succession, and with
       # servers it can be beneficial to avoid doing too many tiny writes so that


### PR DESCRIPTION
by @fizvlad
> I'll save some time to anyone trying to find the rails diff which resulted in this
> 
> [`self.response_body = zip_generator` within gem](https://github.com/fringd/zipline/blob/b2ca413656620e217f74f8eed8fef19ffe3f1924/lib/zipline.rb#L21) calls [`response_body=`](https://github.com/rails/rails/blob/v7.1.2/actionpack/lib/action_controller/metal.rb#L209) method within rails, which calls [`body=`](https://github.com/rails/rails/blob/v7.1.2/actionpack/lib/action_dispatch/http/response.rb#L325) on [`Response`](https://github.com/rails/rails/blob/v7.1.2/actionpack/lib/action_dispatch/http/response.rb#L36) object, which results in assigning of [`Buffer`](https://github.com/rails/rails/blob/v7.1.2/actionpack/lib/action_dispatch/http/response.rb#L98) built based of unchanged `ZipGenerator` to `stream` attribute of buffer
> 
> While responding [Puma checks whether response body responds to `to_ary`](https://github.com/puma/puma/blob/v6.4.0/lib/puma/request.rb#L183) and it does since [this change](https://github.com/rails/rails/pull/47092) and [this change](https://github.com/rails/rails/pull/49616) in Rails repo. Then this `to_ary` method is called on `ZipGenerator`. However Puma does additional check on the result of this method with `array_body.is_a?(Array)` and falls back to `body = res_body` if this check doesn't pass. I believe this PR only works due to Puma making this check and much better option would be supporting call of `ZipGenerator#each` w/o block. Rack also supports `call` method for "streaming body", but I'm not sure it will work, with `Buffer` always responding to `to_ary` 🤔

resolves #91
