### PR TITLE
Apply explicit chunked encoding

### DIFF
--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -28,6 +28,9 @@ module Zipline
       # If HTTP/1.0 is used it is not possible to stream, and if that happens it usually will be
       # unclear why buffering is happening. Some info in the log is the least one can do.
       logger.warn { "The downstream HTTP proxy/LB insists on HTTP/1.0 protocol, ZIP response will be buffered." } if logger
+
+      # Here it would be good natured to to read and save the ZIP into a tempfile, and serve it from there.
+      # Rack has a Rack::TempfileReaper middleware which could be used for that etc. Maybe one day.
       self.response_body = zip_generator
     else
       # Disable buffering for both nginx and Google Load Balancer, see

--- a/lib/zipline.rb
+++ b/lib/zipline.rb
@@ -2,6 +2,7 @@ require 'content_disposition'
 require "zipline/version"
 require 'zip_tricks'
 require "zipline/zip_generator"
+require "zipline/chunked"
 
 # class MyController < ApplicationController
 #   include Zipline
@@ -18,7 +19,28 @@ module Zipline
     headers['Content-Type'] = Mime::Type.lookup_by_extension('zip').to_s
     response.sending_file = true
     response.cache_control[:public] ||= false
-    self.response_body = zip_generator
+
+    # Disables Rack::ETag if it is enabled (prevent buffering)
+    # see https://github.com/rack/rack/issues/1619#issuecomment-606315714
     self.response.headers['Last-Modified'] = Time.now.httpdate
+
+    if request.get_header("HTTP_VERSION") == "HTTP/1.0"
+      # If HTTP/1.0 is used it is not possible to stream, and if that happens it usually will be
+      # unclear why buffering is happening. Some info in the log is the least one can do.
+      logger.warn { "The downstream HTTP proxy/LB insists on HTTP/1.0 protocol, ZIP response will be buffered." } if logger
+      self.response_body = zip_generator
+    else
+      # Disable buffering for both nginx and Google Load Balancer, see
+      # https://cloud.google.com/appengine/docs/flexible/how-requests-are-handled?tab=python#x-accel-buffering
+      response.headers["X-Accel-Buffering"] = "no"
+
+      # Make sure Rack::ContentLength does not try to compute a content length,
+      # and remove the one already set
+      headers.delete("Content-Length")
+
+      # and send out in chunked encoding
+      headers["Transfer-Encoding"] = "chunked"
+      self.response_body = Zipline::Chunked.new(zip_generator)
+    end
   end
 end

--- a/lib/zipline/chunked.rb
+++ b/lib/zipline/chunked.rb
@@ -1,0 +1,31 @@
+module Zipline
+  # A body wrapper that emits chunked responses, creating valid
+  # "Transfer-Encoding: chunked" HTTP response body. This is copied from Rack::Chunked::Body,
+  # because Rack is not going to include that class after version 3.x
+  # Rails has a substitute class for this inside ActionController::Streaming,
+  # but that module is a private constant in the Rails codebase, and is thus
+  # considered "private" from the Rails standpoint. It is not that much code to
+  # carry, so we copy it into our code.
+  class Chunked
+    TERM = "\r\n"
+    TAIL = "0#{TERM}"
+
+    def initialize(body)
+      @body = body
+    end
+
+    # For each string yielded by the response body, yield
+    # the element in chunked encoding - and finish off with a terminator
+    def each
+      term = TERM
+      @body.each do |chunk|
+        size = chunk.bytesize
+        next if size == 0
+
+        yield [size.to_s(16), term, chunk.b, term].join
+      end
+      yield TAIL
+      yield term
+    end
+  end
+end

--- a/lib/zipline/zip_generator.rb
+++ b/lib/zipline/zip_generator.rb
@@ -8,11 +8,6 @@ module Zipline
       @kwargs_for_new = kwargs_for_new
     end
 
-    #this is supposed to be streamed!
-    def to_s
-      throw "stop!"
-    end
-
     def each(&block)
       return to_enum(:each) unless block_given?
 


### PR DESCRIPTION
otherwise it falls on Puma/other Rack server to determine whether chunking has to be applied. While a good-natured webserver is supposed to chunk automatically, why not do it ourselves if we can?