### PR TITLE
Fix the test suite

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'content_disposition', '~> 1.0'
   gem.add_dependency 'zip_tricks', ['>= 4.2.1', '< 6.0']
 
-  # https://github.com/rspec/rspec-mocks/issues/1457
-  gem.add_development_dependency 'rspec-mocks', '3.10.2'
+  gem.add_development_dependency 'rspec-mocks', '>= 3.12.0'
 end


### PR DESCRIPTION
There were some errors because of a bug in rspec-mocks that was duly noted in the gemspec file. This is now fixed, so upgrade and rock on.