### PR TITLE
allow 5.x versions of zip_tricks to be used

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', ['>= 6.0', '< 8.0']
   gem.add_dependency 'content_disposition', '~> 1.0'
-  gem.add_dependency 'zip_tricks', ['~> 4.8', '< 6'] # Minimum to 4.8.3 which is the last-released MIT version
+  gem.add_dependency 'zip_tricks', ['>= 4.8.3', '< 6'] # Minimum to 4.8.3 which is the last-released MIT version
 
   gem.add_development_dependency 'rspec', '~> 3'
   gem.add_development_dependency 'fog-aws'


### PR DESCRIPTION
The change to the gemspec in 1.6.0 was only allowing 4.x versions of `zip_tricks` to be used. Those were from 2020. There are newer 5.x versions from 2021. This change allows bundler to use the newest `zip_tricks`.