### PR TITLE
Replace ZipGenerator with ZipHandler

### DIFF
--- a/zipline.gemspec
+++ b/zipline.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', ['>= 6.0', '< 8.0']
   gem.add_dependency 'content_disposition', '~> 1.0'
-  gem.add_dependency 'zip_kit', ['~> 6', '>= 6.0.1', '< 7']
+  gem.add_dependency 'zip_kit', ['~> 6', '>= 6.2.0', '< 7']
 
   gem.add_development_dependency 'rspec', '~> 3'
   gem.add_development_dependency 'fog-aws'


### PR DESCRIPTION
Move more work into ZipKit, since it already handles the streaming body and the headers. What is important here is that we handle the `files` correctly - which is what the new ZipHandler will do, inside of the streaming ZipKit body. This reduces the number of interacting classes and objects and the number of conditionals.

ZipKit, in turn, will now not apply the `chunked` transfer encoding unless explicitly asked to. This is a follow-through on https://github.com/julik/zip_kit/issues/2 because using ZipKit with an HTTP/2 webserver requires the transfer encoding to be disabled - HTTP/2 framing will be used instead. Following the suggestions from Samuel I have removed the chunking, but it is still possible to force it. Logging streaming exceptions is also easier now, as the entire block handling the ZIP is inside the `each` iteration. There is no tempfile spooling either because it changed the flow drastically (the file would write out at body instantiation, not at iteration over the response).

Note that this removes `ZipGenerator`, so user code that overrides it will require modification. The `ZipHandler` is way smaller though.